### PR TITLE
Add mido as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=['textbeat','textbeat.def','textbeat.presets'],
     include_package_data=True,
     install_requires=[
-        'pygame','colorama','prompt_toolkit','appdirs','pyyaml','docopt','future','shutilwhich'
+        'pygame','colorama','prompt_toolkit','appdirs','pyyaml','docopt','future','shutilwhich','mido'
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
Fix error:
Traceback (most recent call last):
  File "C:\apps\Python\Python37\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "C:\apps\Python\Python37\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "E:\clones\textbeat\textbeat\__main__.py", line 50, in <module>
    from .defs import *
  File "E:\clones\textbeat\textbeat\defs.py", line 10, in <module>
    import mido
ModuleNotFoundError: No module named 'mido'