### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Now with dots for staccato:
 ```
 
 Notes that are played in the same track as other notes mute the previous notes.
-In order to overide this, hold a note by suffixing it with underscore (_).
+In order to override this, hold a note by suffixing it with underscore (_).
 
 A (-) character will then mute them all.
 
@@ -447,7 +447,7 @@ For a full list of GM names, see [def/gm.yaml](https://github.com/flipcoder/text
 The 'T' (tuplet) gives us access to the musical concept of tuplets (called triplets in cases of 3).
 which allows note timing and durations to fall along a ratio instead of the usual note subdivisions.
 
-Tuplets are marked by 'T' and have an optional value at the first occurence in that group.
+Tuplets are marked by 'T' and have an optional value at the first occurrence in that group.
 Ratios provided will control expansion.  Default is 3:4.
 If no denominator is given, it will default to the next power of two
 (so 3:4, 5:8, 7:8, 11:16).
@@ -641,7 +641,7 @@ To do relative values, drop the equals sign:
     - midi channels exceeding max value will be spanned across outputs
 - p: program assign
     - Set program to a given number
-    - Global var (%) p is usually prefered for string matching
+    - Global var (%) p is usually preferred for string matching
 - c: control change (midi CC param)
     - setting CC5 to 25 would be c5:25
 - q: play recording
@@ -687,7 +687,7 @@ Track commands that start with letters should be separated
 from notedata by prefixing '@':
 Example: 1~ is fine, but 1v is not. Use 1@v You only need one to combine: 1@v5e5
 
-Note: Fractional values specified are formated like numbers after a decimal point:
+Note: Fractional values specified are formatted like numbers after a decimal point:
 Example: 3, 30, and 300 all mean 30% (read like .3, .30, etc.)
 
 CC mapping is customizable inside [def/cc.yaml](https://github.com/flipcoder/textbeat/blob/master/textbeat/def/default.yaml).
@@ -757,7 +757,7 @@ Features I'm adding eventually:
 - Recording and encoding output of a project
 - Midi controller input and recording
 - Midi input chord analysis
-- MPE support for temperment and dynamic tonality
+- MPE support for temperament and dynamic tonality
 ```
 
 I'll be making use of python's multiprocessing or

--- a/textbeat/__main__.py
+++ b/textbeat/__main__.py
@@ -27,7 +27,7 @@ Options:
     -p --patch=<patch>    (STUB) default midi patch, partial match
     -f --flags            comma-separated global flags
     -c                    execute commands sequentially
-    -l                    execute commands simultaenously
+    -l                    execute commands simultaneously
     --stdin               read entire file from stdin
     -r --remote           (STUB) realtime remote (control through stdin/out)
     --ring                don't mute midi on end
@@ -133,7 +133,7 @@ def main():
         FN = ARGS['INPUT']
         from_stdin = False
         if FN=='-' or ARGS['--stdin']:
-            FN = 0 # TEMP: doesnt work with py2
+            FN = 0 # TEMP: doesn't work with py2
             from_stdin = True
         else:
             from_stdin = False

--- a/textbeat/parser.py
+++ b/textbeat/parser.py
@@ -37,7 +37,7 @@ def peel_uint_s(s, d=None):
 def peel_roman_s(s, d=None):
     nums = 'ivx'
     r = ''
-    case = -1 # -1 unknown, 0 low, 1 uppper
+    case = -1 # -1 unknown, 0 low, 1 upper
     for ch in s:
         chl = ch.lower()
         chcase = (chl==ch)

--- a/textbeat/player.py
+++ b/textbeat/player.py
@@ -479,7 +479,7 @@ class Player(object):
                                         try:
                                             if val:
                                                 val = val.lower()
-                                                # ambigous alts
+                                                # ambiguous alts
                                                 
                                                 if val.isdigit():
                                                     modescale = (self.scale.name,int(val))
@@ -831,7 +831,7 @@ class Player(object):
                                     tok = tok[1:]
                                     if not expanded: cell = cell[1:]
 
-                            # try to get roman numberal or number
+                            # try to get roman numeral or number
                             c,ct = peel_roman_s(tok)
                             ambiguous = 0
                             # Help parser ambiguities (TODO: make these automatic)
@@ -985,7 +985,7 @@ class Player(object):
                                 except ValueError:
                                     ignore = True
                             else:
-                                ignore = True # reenable if there's a chord listed
+                                ignore = True # re-enable if there's a chord listed
                             
                             # CHORDS
                             addnotes = []
@@ -1168,7 +1168,7 @@ class Player(object):
                                         # chordnoteslist.append(chord_notes)
                                         # chordrootslist.append(chord_root)
                                         chord_root = n
-                                        ignore = False # reenable default root if chord was w/o note name
+                                        ignore = False # re-enable default root if chord was w/o note name
                                         continue
                                     else:
                                         pass
@@ -1252,7 +1252,7 @@ class Player(object):
                     if ch.arp_enabled:
                         if notes: # incoming notes?
                             # log(notes)
-                            # interupt arp
+                            # interrupt arp
                             ch.arp_stop()
                         else:
                             # continue arp
@@ -1708,7 +1708,7 @@ class Player(object):
                         #     if not notes:
                         #         cell = []
                         #         continue # ignore marker
-                        # GLOABL VARS (ignore -- already parsed)
+                        # GLOBAL VARS (ignore -- already parsed)
                         elif c=='%':
                             # ctrl line
                             cell = []

--- a/textbeat/plugins/espeak.py
+++ b/textbeat/plugins/espeak.py
@@ -42,7 +42,7 @@ class BackgroundProcess(object):
                 self.words.clear()
             else:
                 log('BAD COMMAND: ' + msg[0])
-            self.processses = list(filter(lambda p: p.poll()==None, self.processes))
+            self.processes = list(filter(lambda p: p.poll()==None, self.processes))
         self.con.close()
         for tmp in self.words:
             tmp.close()

--- a/textbeat/plugins/sonicpi.py
+++ b/textbeat/plugins/sonicpi.py
@@ -12,9 +12,9 @@ class SonicPi(Instrument):
     NAME = 'sonicpi'
     def __init__(self, args):
         Instrument.__init__(self, SonicPi.NAME)
-        self.initalized = False
+        self.initialized = False
     def enable(self):
-        self.initalized = True
+        self.initialized = True
     def enabled(self):
         return self.initialized
     def supported(self):

--- a/textbeat/plugins/supercollider.py
+++ b/textbeat/plugins/supercollider.py
@@ -16,9 +16,9 @@ class SuperCollider(Instrument):
     NAME = 'supercollider'
     def __init__(self, args):
         Instrument.__init__(self, SuperCollider.NAME)
-        self.initalized = False
+        self.initialized = False
     def enable(self):
-        self.initalized = True
+        self.initialized = True
     def enabled(self):
         return self.enabled
     def supported(self):

--- a/textbeat/theory.py
+++ b/textbeat/theory.py
@@ -95,7 +95,7 @@ DIATONIC = SCALES['diatonic']
 # for lookup, normalize name first, add root to result
 # number chords can't be used with note numbers "C7 but not 17
 # in the future it might be good to lint chord names in a test
-# so that they dont clash with commands and break previous songs if chnaged
+# so that they dont clash with commands and break previous songs if changed
 # This will be replaced for a better parser
 # TODO: need optional notes marked
 CHORDS = DEFS['chords']


### PR DESCRIPTION
Found via `codespell -L halfs,forr,clen`